### PR TITLE
Allow checking against tuple[t1, ...tn] types for n>1

### DIFF
--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -31,10 +31,15 @@ def is_instance(obj, cls):
     outer_type  = cls.__origin__
     inner_types = cls.__args__
 
-    if issubclass(outer_type, (list, tuple, set)):
+    if issubclass(outer_type, (list, set)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         return all(is_instance(item, inner_type) for item in obj)
+
+    if issubclass(outer_type, tuple):
+        if len(inner_types) != len(obj):
+            return False
+        return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
 
     if issubclass(outer_type, dict):
         assert len(inner_types) == 2


### PR DESCRIPTION
Hiya! Long time listener, first time caller.

I noticed that things like 
```python
is_instance(('sup', 'duder', 69), tuple[str, str, int])
```
were failing due to an assertion that `inner_types` were of length 1. This is sensible for `outer_types` in {`set`, `list`}, but it breaks for this common use case of tuple.

This seems to do the trick :)  