### PR TITLE
Provide limited support for parameterized collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A better isinstance for python.
 ## examples
 
 ```python3
-import is_instance
+>>> import is_instance
 
 >>> is_instance(['spam', 'and', 'eggs'], list[str])
 True
@@ -26,6 +26,11 @@ True
 False
 
 >>> is_instance([{'a': 1, 'b': None}, {'a': 3, 'b': 4}], list[dict[str, int|None]])
+True
+
+>>> from collections.abc import Sequence
+
+>>> is_instance('cake', Sequence[str])
 True
 ```
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Sequence
+from collections.abc import Container, Iterable, Mapping, Sequence
 from functools import reduce
 from operator import or_
 
@@ -38,12 +38,7 @@ def is_instance(obj, cls):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
 
-    if issubclass(outer_type, (list, set, Sequence)):
-        assert len(inner_types) == 1
-        [inner_type] = inner_types
-        return all(is_instance(item, inner_type) for item in obj)
-
-    if issubclass(outer_type, dict):
+    if issubclass(outer_type, Mapping):
         assert len(inner_types) == 2
         key_type, val_type = inner_types
         return all(
@@ -51,6 +46,11 @@ def is_instance(obj, cls):
             is_instance(val, val_type) for
             key, val in obj.items()
         )
+
+    if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
+        assert len(inner_types) == 1
+        [inner_type] = inner_types
+        return all(is_instance(item, inner_type) for item in obj)
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -31,7 +31,7 @@ def is_instance(obj, cls):
         return False
 
     outer_type  = cls.__origin__
-    inner_types = cls.__args__
+    inner_types = typing.get_args(cls)
 
     if issubclass(outer_type, tuple):
         if len(inner_types) != len(obj):
@@ -51,6 +51,12 @@ def is_instance(obj, cls):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         return all(is_instance(item, inner_type) for item in obj)
+
+    if issubclass(outer_type, Callable):
+        raise NotImplementedError("Callable not yet supported")
+
+    if issubclass(outer_type, Generator):
+        raise NotImplementedError("Generator not yet supported")
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -34,6 +34,8 @@ def is_instance(obj, cls):
     inner_types = typing.get_args(cls)
 
     if issubclass(outer_type, tuple):
+        if Ellipsis in inner_types:
+            raise NotImplementedError("Ellipsis not yet supported")
         if len(inner_types) != len(obj):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,6 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
+from collections.abc import Sequence
 from functools import reduce
 from operator import or_
 
@@ -37,7 +38,7 @@ def is_instance(obj, cls):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
 
-    if issubclass(outer_type, (list, set, typing.Sequence)):
+    if issubclass(outer_type, (list, set, Sequence)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         return all(is_instance(item, inner_type) for item in obj)

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -1,3 +1,13 @@
+from collections.abc import (
+    Collection,
+    Container,
+    Iterable,
+    Iterator,
+    Mapping,
+    Reversible,
+    Sequence,
+)
+
 import is_instance
 
 def test_compat():
@@ -44,6 +54,30 @@ def test_slang():
     assert is_instance([d1, d2], [{str: int}])
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
+
+def test_collection():
+    assert is_instance(["cake"], Collection[str])
+    assert not is_instance(["cake"], Collection[int])
+
+def test_container():
+    assert is_instance(["cake"], Container[str])
+    assert not is_instance(["cake"], Container[int])
+
+def test_iterable():
+    assert is_instance(["cake"], Iterable[str])
+    assert not is_instance(["cake"], Iterable[int])
+
+def test_iterator():
+    assert is_instance(iter(["cake"]), Iterator[str])
+    assert not is_instance(iter(["cake"]), Iterator[int])
+
+def test_mapping():
+    assert is_instance({"cake": "pie"}, Mapping[str, str])
+    assert not is_instance({"cake": "pie"}, Mapping[str, int])
+
+def test_reversible():
+    assert is_instance(["cake"], Reversible[str])
+    assert not is_instance(["cake"], Reversible[int])
 
 def test_sequence():
     assert is_instance(["cake"], Sequence[str])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -32,11 +32,6 @@ def test_typed_tuples():
     assert not isinstance(('cake', 'pie', 42), (str, str, int))
     assert not is_instance(('cake', 'pie', 42), (str, str, int))
 
-def test_sequence():
-    from typing import Sequence
-    assert is_instance(['cake'], Sequence[str])
-    assert not is_instance(['cake'], Sequence[int])
-
 def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}
@@ -49,3 +44,7 @@ def test_slang():
     assert is_instance([d1, d2], [{str: int}])
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
+
+def test_sequence():
+    assert is_instance(["cake"], Sequence[str])
+    assert not is_instance(["cake"], Sequence[int])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -1,6 +1,8 @@
 from collections.abc import (
+    Callable,
     Collection,
     Container,
+    Generator,
     Iterable,
     Iterator,
     Mapping,
@@ -55,6 +57,16 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
 
+def test_callable():
+    assert not is_instance(lambda: None, Callable[[str], None])
+    assert is_instance(lambda: None, Callable[[], None])
+    def fun(x: str) -> None: ...
+    assert is_instance(fun, Callable[[str], None])
+    def fun(x: str, y: int) -> None: ...
+    assert is_instance(fun, Callable[[str, int], None])
+    def fun(x: str, y: int) -> bool: ...
+    assert is_instance(fun, Callable[[str, int], bool])
+
 def test_collection():
     assert is_instance(["cake"], Collection[str])
     assert not is_instance(["cake"], Collection[int])
@@ -62,6 +74,11 @@ def test_collection():
 def test_container():
     assert is_instance(["cake"], Container[str])
     assert not is_instance(["cake"], Container[int])
+
+def test_generator():
+    assert is_instance((_ for _ in "__"), Generator[str, None, None])
+    assert not is_instance((_ for _ in "__"), Generator[int, None, None])
+    # TODO: test Generator[...] + send/receive
 
 def test_iterable():
     assert is_instance(["cake"], Iterable[str])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -44,6 +44,10 @@ def test_typed_tuples():
     assert not isinstance(('cake', 'pie', 42), (str, str, int))
     assert not is_instance(('cake', 'pie', 42), (str, str, int))
 
+    assert is_instance((), tuple[int, ...])
+    assert is_instance((1,), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ...])
+
 def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}


### PR DESCRIPTION
Tests are now passing for Collection, Container, Iterable, Iterator, Mapping, and Reversible in addition to Sequence. I also added placeholders for but have not implemented Callable and Generator. In addition, I added some failing test cases for `tuple[int, ...]`.