### PR TITLE
Improve support for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is_instance
 
-A better isinstance for python.
+A better `isinstance` for Python.
 
 ## examples
 
@@ -37,7 +37,7 @@ True
 The following type slang is also supported, inspired by the Haskell type system.
 
 ```python3
-import is_instance
+>>> import is_instance
 
 >>> is_instance(['spam', 'and', 'eggs'], [str])
 True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ description = "A better isinstance for python"
 dependencies = [
     "callable_module",
 ]
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 develop = [

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -27,6 +27,9 @@ def is_instance(obj, cls, /) -> bool:
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 
+    if isinstance(cls, typing._LiteralGenericAlias):
+        return obj in cls.__args__
+
     if not is_instance(obj, cls.__origin__):
         return False
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,15 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
+from collections.abc import (
+    Callable,
+    Container,
+    Generator,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from functools import reduce
 from operator import or_
 
@@ -52,10 +60,17 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Generator):
         raise NotImplementedError('Generator not yet supported')
 
+    if issubclass(outer_type, Iterator):
+        raise NotImplementedError('Iterator not yet supported')
+
     if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
-        return all(is_instance(item, inner_type) for item in obj)
+        if len(obj):
+            return all(is_instance(item, inner_type) for item in obj)
+        if isinstance(obj, str) and inner_type is not str:
+            return False
+        return True
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError('Callable not yet supported')

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls):
+def is_instance(obj, cls, /) -> bool:
 
     """ Turducken typing. """
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -63,7 +63,7 @@ def is_instance(obj, cls):
     raise TypeError(obj, cls)
 
 
-if sys.version >= '3.11':
+if sys.version_info >= (3, 11):
     # translate_slang needs to write cls[*obj],
     # which is apparently a syntax error in older
     # versions of python, so we shouldn't even

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -35,7 +35,7 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, tuple):
         if Ellipsis in inner_types:
-            raise NotImplementedError("Ellipsis not yet supported")
+            raise NotImplementedError('Ellipsis not yet supported')
         if len(inner_types) != len(obj):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
@@ -55,10 +55,10 @@ def is_instance(obj, cls):
         return all(is_instance(item, inner_type) for item in obj)
 
     if issubclass(outer_type, Callable):
-        raise NotImplementedError("Callable not yet supported")
+        raise NotImplementedError('Callable not yet supported')
 
     if issubclass(outer_type, Generator):
-        raise NotImplementedError("Generator not yet supported")
+        raise NotImplementedError('Generator not yet supported')
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,15 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import (
-    Callable,
-    Container,
-    Generator,
-    Iterable,
-    Iterator,
-    Mapping,
-    Sequence,
-)
+from collections.abc import Callable, Container, Generator, Iterable, Iterator, Mapping
 from functools import reduce
 from operator import or_
 
@@ -63,7 +55,7 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Iterator):
         raise NotImplementedError('Iterator not yet supported')
 
-    if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
+    if issubclass(outer_type, (Container, Iterable)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         if len(obj):

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -49,6 +49,9 @@ def is_instance(obj, cls):
             key, val in obj.items()
         )
 
+    if issubclass(outer_type, Generator):
+        raise NotImplementedError('Generator not yet supported')
+
     if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
@@ -56,9 +59,6 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError('Callable not yet supported')
-
-    if issubclass(outer_type, Generator):
-        raise NotImplementedError('Generator not yet supported')
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -60,9 +60,7 @@ def is_instance(obj, cls, /) -> bool:
         [inner_type] = inner_types
         if len(obj):
             return all(is_instance(item, inner_type) for item in obj)
-        if isinstance(obj, str) and inner_type is not str:
-            return False
-        return True
+        return is_instance(obj, inner_type) or hasattr(obj, '__class_getitem__')
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError('Callable not yet supported')

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -24,6 +24,9 @@ def is_instance(obj, cls, /) -> bool:
     if isinstance(cls, (list, set, dict)):
         cls = translate_slang(cls)
 
+    if cls is None:
+        cls = types.NoneType
+
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Container, Iterable, Mapping, Sequence
+from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
 from functools import reduce
 from operator import or_
 

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -6,9 +6,14 @@ from collections.abc import (
     Iterable,
     Iterator,
     Mapping,
+    MutableMapping,
+    MutableSequence,
+    MutableSet,
     Reversible,
     Sequence,
+    Set,
 )
+from types import MappingProxyType
 
 import is_instance
 
@@ -77,6 +82,11 @@ def test_mapping():
     assert not is_instance({'': ''}, Mapping[str, int])
     assert not is_instance('', Mapping)
 
+def test_mutable_mapping():
+    assert is_instance({'': 0}, MutableMapping[str, int])
+    assert not is_instance({'': 0}, MutableMapping[str, str])
+    assert not is_instance(MappingProxyType({}), MutableMapping)
+
 def test_reversible():
     assert is_instance('', Reversible[str])
     assert not is_instance('', Reversible[int])
@@ -86,6 +96,21 @@ def test_sequence():
     assert is_instance('', Sequence[str])
     assert not is_instance('', Sequence[int])
     assert not is_instance(set(), Sequence)
+
+def test_set():
+    assert is_instance({0}, Set[int])
+    assert not is_instance({0}, Set[str])
+    assert not is_instance([], Set)
+
+def test_mutable_set():
+    assert is_instance({0}, MutableSet[int])
+    assert not is_instance({0}, MutableSet[str])
+    assert not is_instance(frozenset(), MutableSet)
+
+def test_mutable_sequence():
+    assert is_instance([''], MutableSequence[str])
+    assert not is_instance([''], MutableSequence[int])
+    assert not is_instance('', MutableSequence)
 
 ############
 ### TODO ###

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -72,11 +72,6 @@ def test_iterable():
     assert not is_instance('', Iterable[int])
     assert not is_instance(0, Iterable)
 
-def test_iterator():
-    assert is_instance(iter(''), Iterator[str])
-    assert not is_instance(iter(''), Iterator[int])
-    assert not is_instance('', Iterator)
-
 def test_mapping():
     assert is_instance({'': 0}, Mapping[str, int])
     assert not is_instance({'': ''}, Mapping[str, int])
@@ -95,6 +90,11 @@ def test_sequence():
 ############
 ### TODO ###
 ############
+
+def TODO_test_iterator():
+    assert is_instance(iter(''), Iterator[str])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)
 
 def TODO_test_callable():
     assert not is_instance(lambda: None, Callable[[str], None])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -62,6 +62,13 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
 
+def test_literal():
+    assert is_instance('', Literal[''])
+    assert is_instance('', Literal['', 0])
+    assert is_instance('', Literal[Literal['']])
+    assert not is_instance(Literal[''], Literal[Literal['']])
+    assert not is_instance('', Literal[0])
+
 def test_collection():
     assert is_instance('', Collection[str])
     assert is_instance('', Collection[Collection[str]])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -58,32 +58,39 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(['cake'], Collection[str])
-    assert not is_instance(['cake'], Collection[int])
+    assert is_instance('', Collection[str])
+    assert not is_instance('', Collection[int])
+    assert not is_instance(0, Collection)
 
 def test_container():
-    assert is_instance(['cake'], Container[str])
-    assert not is_instance(['cake'], Container[int])
+    assert is_instance('', Container[str])
+    assert not is_instance('', Container[int])
+    assert not is_instance(0, Container)
 
 def test_iterable():
-    assert is_instance(['cake'], Iterable[str])
-    assert not is_instance(['cake'], Iterable[int])
+    assert is_instance('', Iterable[str])
+    assert not is_instance('', Iterable[int])
+    assert not is_instance(0, Iterable)
 
 def test_iterator():
-    assert is_instance(iter(['cake']), Iterator[str])
-    assert not is_instance(iter(['cake']), Iterator[int])
+    assert is_instance(iter(''), Iterator[str])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)
 
 def test_mapping():
-    assert is_instance({'cake': 'pie'}, Mapping[str, str])
-    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
+    assert is_instance({'': 0}, Mapping[str, int])
+    assert not is_instance({'': ''}, Mapping[str, int])
+    assert not is_instance('', Mapping)
 
 def test_reversible():
-    assert is_instance(['cake'], Reversible[str])
-    assert not is_instance(['cake'], Reversible[int])
+    assert is_instance('', Reversible[str])
+    assert not is_instance('', Reversible[int])
+    assert not is_instance(set(), Reversible)
 
 def test_sequence():
-    assert is_instance(['cake'], Sequence[str])
-    assert not is_instance(['cake'], Sequence[int])
+    assert is_instance('', Sequence[str])
+    assert not is_instance('', Sequence[int])
+    assert not is_instance(set(), Sequence)
 
 ############
 ### TODO ###
@@ -105,6 +112,6 @@ def TODO_test_typed_tuples_ellipsis():
     assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_generator():
-    assert is_instance((_ for _ in '__'), Generator[str, None, None])
-    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
+    assert is_instance((_ for _ in ''), Generator[str, None, None])
+    assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -58,32 +58,32 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(["cake"], Collection[str])
-    assert not is_instance(["cake"], Collection[int])
+    assert is_instance(['cake'], Collection[str])
+    assert not is_instance(['cake'], Collection[int])
 
 def test_container():
-    assert is_instance(["cake"], Container[str])
-    assert not is_instance(["cake"], Container[int])
+    assert is_instance(['cake'], Container[str])
+    assert not is_instance(['cake'], Container[int])
 
 def test_iterable():
-    assert is_instance(["cake"], Iterable[str])
-    assert not is_instance(["cake"], Iterable[int])
+    assert is_instance(['cake'], Iterable[str])
+    assert not is_instance(['cake'], Iterable[int])
 
 def test_iterator():
-    assert is_instance(iter(["cake"]), Iterator[str])
-    assert not is_instance(iter(["cake"]), Iterator[int])
+    assert is_instance(iter(['cake']), Iterator[str])
+    assert not is_instance(iter(['cake']), Iterator[int])
 
 def test_mapping():
-    assert is_instance({"cake": "pie"}, Mapping[str, str])
-    assert not is_instance({"cake": "pie"}, Mapping[str, int])
+    assert is_instance({'cake': 'pie'}, Mapping[str, str])
+    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
 
 def test_reversible():
-    assert is_instance(["cake"], Reversible[str])
-    assert not is_instance(["cake"], Reversible[int])
+    assert is_instance(['cake'], Reversible[str])
+    assert not is_instance(['cake'], Reversible[int])
 
 def test_sequence():
-    assert is_instance(["cake"], Sequence[str])
-    assert not is_instance(["cake"], Sequence[int])
+    assert is_instance(['cake'], Sequence[str])
+    assert not is_instance(['cake'], Sequence[int])
 
 ############
 ### TODO ###
@@ -105,6 +105,6 @@ def TODO_test_typed_tuples_ellipsis():
     assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_generator():
-    assert is_instance((_ for _ in "__"), Generator[str, None, None])
-    assert not is_instance((_ for _ in "__"), Generator[int, None, None])
+    assert is_instance((_ for _ in '__'), Generator[str, None, None])
+    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -22,7 +22,6 @@ def test_compat():
     assert is_instance('spam', str)
     assert is_instance('spam', (str, int))
     assert is_instance(True, int)
-    assert is_instance(None, None)
     assert not is_instance('spam', int)
     assert not is_instance('spam', (float, int))
     assert not is_instance(True, float)
@@ -55,6 +54,7 @@ def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}
     assert is_instance(['spam', 'and', 'eggs'], [str])
+    assert is_instance(None, None)
     assert is_instance([], [int])
     assert is_instance({1, 2, 3}, {int})
     assert is_instance({'bird': True, 'alive': False}, {str: bool})

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -97,6 +97,11 @@ def test_sequence():
     assert not is_instance('', Sequence[int])
     assert not is_instance(set(), Sequence)
 
+def test_mutable_sequence():
+    assert is_instance([''], MutableSequence[str])
+    assert not is_instance([''], MutableSequence[int])
+    assert not is_instance('', MutableSequence)
+
 def test_set():
     assert is_instance({0}, Set[int])
     assert not is_instance({0}, Set[str])
@@ -107,19 +112,14 @@ def test_mutable_set():
     assert not is_instance({0}, MutableSet[str])
     assert not is_instance(frozenset(), MutableSet)
 
-def test_mutable_sequence():
-    assert is_instance([''], MutableSequence[str])
-    assert not is_instance([''], MutableSequence[int])
-    assert not is_instance('', MutableSequence)
-
 ############
 ### TODO ###
 ############
 
-def TODO_test_iterator():
-    assert is_instance(iter(''), Iterator[str])
-    assert not is_instance(iter(''), Iterator[int])
-    assert not is_instance('', Iterator)
+def TODO_test_typed_tuples_ellipsis():
+    assert is_instance((), tuple[int, ...])
+    assert is_instance((1,), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_callable():
     assert not is_instance(lambda: None, Callable[[str], None])
@@ -131,12 +131,12 @@ def TODO_test_callable():
     def fun(x: str, y: int) -> bool: ...
     assert is_instance(fun, Callable[[str, int], bool])
 
-def TODO_test_typed_tuples_ellipsis():
-    assert is_instance((), tuple[int, ...])
-    assert is_instance((1,), tuple[int, ...])
-    assert is_instance((1, 2), tuple[int, ...])
-
 def TODO_test_generator():
     assert is_instance((_ for _ in ''), Generator[str, None, None])
     assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive
+
+def TODO_test_iterator():
+    assert is_instance(iter(''), Iterator[str])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -78,13 +78,13 @@ def test_iterable():
     assert not is_instance(0, Iterable)
 
 def test_mapping():
-    assert is_instance({'': 0}, Mapping[str, int])
+    assert is_instance({'': ''}, Mapping[str, str])
     assert not is_instance({'': ''}, Mapping[str, int])
     assert not is_instance('', Mapping)
 
 def test_mutable_mapping():
-    assert is_instance({'': 0}, MutableMapping[str, int])
-    assert not is_instance({'': 0}, MutableMapping[str, str])
+    assert is_instance({'': ''}, MutableMapping[str, str])
+    assert not is_instance({'': ''}, MutableMapping[str, int])
     assert not is_instance(MappingProxyType({}), MutableMapping)
 
 def test_reversible():
@@ -103,13 +103,13 @@ def test_mutable_sequence():
     assert not is_instance('', MutableSequence)
 
 def test_set():
-    assert is_instance({0}, Set[int])
-    assert not is_instance({0}, Set[str])
+    assert is_instance({''}, Set[str])
+    assert not is_instance({''}, Set[int])
     assert not is_instance([], Set)
 
 def test_mutable_set():
-    assert is_instance({0}, MutableSet[int])
-    assert not is_instance({0}, MutableSet[str])
+    assert is_instance({''}, MutableSet[str])
+    assert not is_instance({''}, MutableSet[int])
     assert not is_instance(frozenset(), MutableSet)
 
 ############

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -14,6 +14,7 @@ from collections.abc import (
     Set,
 )
 from types import MappingProxyType
+from typing import Literal
 
 import is_instance
 

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -64,16 +64,19 @@ def test_slang():
 
 def test_collection():
     assert is_instance('', Collection[str])
+    assert is_instance('', Collection[Collection[str]])
     assert not is_instance('', Collection[int])
     assert not is_instance(0, Collection)
 
 def test_container():
     assert is_instance('', Container[str])
+    assert is_instance('', Container[Container[str]])
     assert not is_instance('', Container[int])
     assert not is_instance(0, Container)
 
 def test_iterable():
     assert is_instance('', Iterable[str])
+    assert is_instance('', Iterable[Iterable[str]])
     assert not is_instance('', Iterable[int])
     assert not is_instance(0, Iterable)
 
@@ -89,11 +92,13 @@ def test_mutable_mapping():
 
 def test_reversible():
     assert is_instance('', Reversible[str])
+    assert is_instance('', Reversible[Reversible[str]])
     assert not is_instance('', Reversible[int])
     assert not is_instance(set(), Reversible)
 
 def test_sequence():
     assert is_instance('', Sequence[str])
+    assert is_instance('', Sequence[Sequence[str]])
     assert not is_instance('', Sequence[int])
     assert not is_instance(set(), Sequence)
 

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -22,6 +22,7 @@ def test_compat():
     assert is_instance('spam', str)
     assert is_instance('spam', (str, int))
     assert is_instance(True, int)
+    assert is_instance(None, None)
     assert not is_instance('spam', int)
     assert not is_instance('spam', (float, int))
     assert not is_instance(True, float)


### PR DESCRIPTION
- Tests were revised to surface some bugs (https://github.com/notarealdeveloper/is_instance/commit/41d127e2be8aad91a169169f86c298ff90dcbdc1 & https://github.com/notarealdeveloper/is_instance/pull/6/commits/f1a8b52bc82c7e86c6255fb590f4737f1d0e9635) and the corresponding code was fixed (https://github.com/notarealdeveloper/is_instance/pull/6/commits/c36760975b54578b3fef0dff4ed6fb421cf7d65f) so that all but one of those tests pass.
- Support has been added for `MutableMapping`, `MutableSequence`, `MutableSet`, and `Set` from `collections.abc` (https://github.com/notarealdeveloper/is_instance/commit/f57d79aa3b34b92f2f291e0da5bb972e874305c3), but `test_iterator` is still failing for `iter('')`.
- I also fixed a bug by replacing sys.version with sys.version_info (https://github.com/notarealdeveloper/is_instance/commit/27a4415f8bd2361753045e154f0123e218c991a7).
- Parameters are now positional-only to mirror the original `isinstance` (https://github.com/notarealdeveloper/is_instance/pull/6/commits/2ca46518a2ca003ca98b226a5150081fc9d87374)
- Python >= 3.10 was added to `pyproject.toml` (https://github.com/notarealdeveloper/is_instance/pull/6/commits/5f317c436367b5452a4b90df71844f631adc6c1e)
- `typing.Literal` is now supported (https://github.com/notarealdeveloper/is_instance/pull/6/commits/ddc3a7d15b9124fc16aa7e68412e65b701edc0bc) as well as `NoneType` (https://github.com/notarealdeveloper/is_instance/pull/6/commits/a211afb697ac049aa10799e744f4234ce3ecbb2b)

(https://github.com/notarealdeveloper/is_instance/pull/6/commits/c36760975b54578b3fef0dff4ed6fb421cf7d65f supersedes 514ebf3 while f1a8b52 could be consolidated with bbe10d1 along with 41d127e. If you'd prefer, I can close this PR and resubmit a more concise one.)