### PR TITLE
Improve support for collections.abc, typing.Literal, and types.NoneType

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is_instance
 
-A better isinstance for python.
+A better `isinstance` for Python.
 
 ## examples
 
@@ -37,7 +37,7 @@ True
 The following type slang is also supported, inspired by the Haskell type system.
 
 ```python3
-import is_instance
+>>> import is_instance
 
 >>> is_instance(['spam', 'and', 'eggs'], [str])
 True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ description = "A better isinstance for python"
 dependencies = [
     "callable_module",
 ]
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 develop = [

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -30,6 +30,9 @@ def is_instance(obj, cls):
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 
+    if isinstance(cls, typing._LiteralGenericAlias):
+        return obj in cls.__args__
+
     if not is_instance(obj, cls.__origin__):
         return False
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -63,7 +63,7 @@ def is_instance(obj, cls):
     raise TypeError(obj, cls)
 
 
-if sys.version >= '3.11':
+if sys.version_info >= (3, 11):
     # translate_slang needs to write cls[*obj],
     # which is apparently a syntax error in older
     # versions of python, so we shouldn't even

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
+from collections.abc import Callable, Container, Generator, Iterable, Mapping
 from functools import reduce
 from operator import or_
 
@@ -52,7 +52,7 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Generator):
         raise NotImplementedError('Generator not yet supported')
 
-    if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
+    if issubclass(outer_type, (Container, Iterable)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         return all(is_instance(item, inner_type) for item in obj)

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls) -> bool:
+def is_instance(obj, cls, /) -> bool:
 
     ''' Turducken typing. '''
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Callable, Container, Generator, Iterable, Mapping
+from collections.abc import Callable, Container, Generator, Iterable, Iterator, Mapping
 from functools import reduce
 from operator import or_
 
@@ -52,10 +52,15 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Generator):
         raise NotImplementedError('Generator not yet supported')
 
+    if issubclass(outer_type, Iterator):
+        raise NotImplementedError('Iterator not yet supported')
+
     if issubclass(outer_type, (Container, Iterable)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
-        return all(is_instance(item, inner_type) for item in obj)
+        if len(obj):
+            return all(is_instance(item, inner_type) for item in obj)
+        return is_instance(obj, inner_type) or hasattr(obj, '__class_getitem__')
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError('Callable not yet supported')

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -24,6 +24,9 @@ def is_instance(obj, cls):
     if isinstance(cls, (list, set, dict)):
         cls = translate_slang(cls)
 
+    if cls is None:
+        cls = types.NoneType
+
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -11,7 +11,7 @@ from operator import or_
 
 def is_instance(obj, cls):
 
-    """ Turducken typing. """
+    ''' Turducken typing. '''
 
     if isinstance(cls, tuple):
         if all(isinstance(sub, type) for sub in cls):
@@ -35,7 +35,7 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, tuple):
         if Ellipsis in inner_types:
-            raise NotImplementedError("Ellipsis not yet supported")
+            raise NotImplementedError('Ellipsis not yet supported')
         if len(inner_types) != len(obj):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
@@ -58,7 +58,7 @@ def is_instance(obj, cls):
         return all(is_instance(item, inner_type) for item in obj)
 
     if issubclass(outer_type, Callable):
-        raise NotImplementedError("Callable not yet supported")
+        raise NotImplementedError('Callable not yet supported')
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls):
+def is_instance(obj, cls) -> bool:
 
     ''' Turducken typing. '''
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -49,6 +49,9 @@ def is_instance(obj, cls):
             key, val in obj.items()
         )
 
+    if issubclass(outer_type, Generator):
+        raise NotImplementedError('Generator not yet supported')
+
     if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
@@ -56,9 +59,6 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError("Callable not yet supported")
-
-    if issubclass(outer_type, Generator):
-        raise NotImplementedError("Generator not yet supported")
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Container, Iterable, Mapping, Sequence
+from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
 from functools import reduce
 from operator import or_
 

--- a/src/is_instance/slang.py
+++ b/src/is_instance/slang.py
@@ -2,7 +2,7 @@ __all__ = [
     'translate_slang',
 ]
 def translate_slang(obj):
-    """
+    '''
     Slang for the haskell type system.
 
     Allows using abbreviations like:
@@ -15,9 +15,9 @@ def translate_slang(obj):
 
     Lets us talk about types in a better way
     without having to actually use haskell.
-    """
+    '''
     if len(obj) != 1:
-        raise TypeError(f"Not a valid type schema")
+        raise TypeError(f'Not a valid type schema')
     for cls in (tuple, list, set):
         if isinstance(obj, cls):
             return cls[*obj]

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -6,9 +6,14 @@ from collections.abc import (
     Iterable,
     Iterator,
     Mapping,
+    MutableMapping,
+    MutableSequence,
+    MutableSet,
     Reversible,
     Sequence,
+    Set,
 )
+from types import MappingProxyType
 from typing import Literal
 
 import is_instance
@@ -89,6 +94,11 @@ def test_mapping():
     assert not is_instance({'': ''}, Mapping[str, int])
     assert not is_instance('', Mapping)
 
+def test_mutable_mapping():
+    assert is_instance({'': ''}, MutableMapping[str, str])
+    assert not is_instance({'': ''}, MutableMapping[str, int])
+    assert not is_instance(MappingProxyType({}), MutableMapping)
+
 def test_reversible():
     assert is_instance('', Reversible[str])
     assert is_instance('', Reversible[Reversible[str]])
@@ -100,6 +110,23 @@ def test_sequence():
     assert is_instance('', Sequence[Sequence[str]])
     assert not is_instance('', Sequence[int])
     assert not is_instance(set(), Sequence)
+
+def test_mutable_sequence():
+    assert is_instance([''], MutableSequence[str])
+    assert is_instance([[]], MutableSequence[MutableSequence[None]])
+    assert not is_instance([''], MutableSequence[int])
+    assert not is_instance('', MutableSequence)
+
+def test_set():
+    assert is_instance({''}, Set[str])
+    assert is_instance({frozenset()}, Set[Set[None]])
+    assert not is_instance({''}, Set[int])
+    assert not is_instance([], Set)
+
+def test_mutable_set():
+    assert is_instance({''}, MutableSet[str])
+    assert not is_instance({''}, MutableSet[int])
+    assert not is_instance(frozenset(), MutableSet)
 
 ############
 ### TODO ###

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Reversible,
     Sequence,
 )
+from typing import Literal
 
 import is_instance
 
@@ -57,6 +58,13 @@ def test_slang():
     assert is_instance([d1, d2], [{str: int}])
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
+
+def test_literal():
+    assert is_instance('', Literal[''])
+    assert is_instance('', Literal['', 0])
+    assert is_instance('', Literal[Literal['']])
+    assert not is_instance(Literal[''], Literal[Literal['']])
+    assert not is_instance('', Literal[0])
 
 def test_collection():
     assert is_instance('', Collection[str])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -58,32 +58,32 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(["cake"], Collection[str])
-    assert not is_instance(["cake"], Collection[int])
+    assert is_instance(['cake'], Collection[str])
+    assert not is_instance(['cake'], Collection[int])
 
 def test_container():
-    assert is_instance(["cake"], Container[str])
-    assert not is_instance(["cake"], Container[int])
+    assert is_instance(['cake'], Container[str])
+    assert not is_instance(['cake'], Container[int])
 
 def test_iterable():
-    assert is_instance(["cake"], Iterable[str])
-    assert not is_instance(["cake"], Iterable[int])
+    assert is_instance(['cake'], Iterable[str])
+    assert not is_instance(['cake'], Iterable[int])
 
 def test_iterator():
-    assert is_instance(iter(["cake"]), Iterator[str])
-    assert not is_instance(iter(["cake"]), Iterator[int])
+    assert is_instance(iter(['cake']), Iterator[str])
+    assert not is_instance(iter(['cake']), Iterator[int])
 
 def test_mapping():
-    assert is_instance({"cake": "pie"}, Mapping[str, str])
-    assert not is_instance({"cake": "pie"}, Mapping[str, int])
+    assert is_instance({'cake': 'pie'}, Mapping[str, str])
+    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
 
 def test_reversible():
-    assert is_instance(["cake"], Reversible[str])
-    assert not is_instance(["cake"], Reversible[int])
+    assert is_instance(['cake'], Reversible[str])
+    assert not is_instance(['cake'], Reversible[int])
 
 def test_sequence():
-    assert is_instance(["cake"], Sequence[str])
-    assert not is_instance(["cake"], Sequence[int])
+    assert is_instance(['cake'], Sequence[str])
+    assert not is_instance(['cake'], Sequence[int])
 
 ############
 ### TODO ###
@@ -105,6 +105,6 @@ def TODO_test_typed_tuples_ellipsis():
     assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_generator():
-    assert is_instance((_ for _ in "__"), Generator[str, None, None])
-    assert not is_instance((_ for _ in "__"), Generator[int, None, None])
+    assert is_instance((_ for _ in '__'), Generator[str, None, None])
+    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -76,11 +76,6 @@ def test_iterable():
     assert not is_instance('', Iterable[int])
     assert not is_instance(0, Iterable)
 
-def test_iterator():
-    assert is_instance(iter(''), Iterator[str])
-    assert not is_instance(iter(''), Iterator[int])
-    assert not is_instance('', Iterator)
-
 def test_mapping():
     assert is_instance({'': ''}, Mapping[str, str])
     assert not is_instance({'': ''}, Mapping[str, int])
@@ -114,10 +109,16 @@ def TODO_test_callable():
     assert is_instance(fun, Callable[[str], None])
     def fun(x: str, y: int) -> None: ...
     assert is_instance(fun, Callable[[str, int], None])
-    def fun(x: str, y: int) -> bool: ...
-    assert is_instance(fun, Callable[[str, int], bool])
+    def fun(x: None) -> str: ...
+    assert is_instance(fun, Callable[[None], str])
 
 def TODO_test_generator():
     assert is_instance((_ for _ in ''), Generator[str, None, None])
     assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive
+
+def TODO_test_iterator():
+    assert is_instance(iter(''), Iterator[str])
+    assert is_instance(iter(iter('')), Iterator[Iterator[str]])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -48,6 +48,7 @@ def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}
     assert is_instance(['spam', 'and', 'eggs'], [str])
+    assert is_instance(None, None)
     assert is_instance([], [int])
     assert is_instance({1, 2, 3}, {int})
     assert is_instance({'bird': True, 'alive': False}, {str: bool})
@@ -58,36 +59,53 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(['cake'], Collection[str])
-    assert not is_instance(['cake'], Collection[int])
+    assert is_instance('', Collection[str])
+    assert is_instance('', Collection[Collection[str]])
+    assert not is_instance('', Collection[int])
+    assert not is_instance(0, Collection)
 
 def test_container():
-    assert is_instance(['cake'], Container[str])
-    assert not is_instance(['cake'], Container[int])
+    assert is_instance('', Container[str])
+    assert is_instance('', Container[Container[str]])
+    assert not is_instance('', Container[int])
+    assert not is_instance(0, Container)
 
 def test_iterable():
-    assert is_instance(['cake'], Iterable[str])
-    assert not is_instance(['cake'], Iterable[int])
+    assert is_instance('', Iterable[str])
+    assert is_instance('', Iterable[Iterable[str]])
+    assert not is_instance('', Iterable[int])
+    assert not is_instance(0, Iterable)
 
 def test_iterator():
-    assert is_instance(iter(['cake']), Iterator[str])
-    assert not is_instance(iter(['cake']), Iterator[int])
+    assert is_instance(iter(''), Iterator[str])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)
 
 def test_mapping():
-    assert is_instance({'cake': 'pie'}, Mapping[str, str])
-    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
+    assert is_instance({'': ''}, Mapping[str, str])
+    assert not is_instance({'': ''}, Mapping[str, int])
+    assert not is_instance('', Mapping)
 
 def test_reversible():
-    assert is_instance(['cake'], Reversible[str])
-    assert not is_instance(['cake'], Reversible[int])
+    assert is_instance('', Reversible[str])
+    assert is_instance('', Reversible[Reversible[str]])
+    assert not is_instance('', Reversible[int])
+    assert not is_instance(set(), Reversible)
 
 def test_sequence():
-    assert is_instance(['cake'], Sequence[str])
-    assert not is_instance(['cake'], Sequence[int])
+    assert is_instance('', Sequence[str])
+    assert is_instance('', Sequence[Sequence[str]])
+    assert not is_instance('', Sequence[int])
+    assert not is_instance(set(), Sequence)
 
 ############
 ### TODO ###
 ############
+
+def TODO_test_typed_tuples_ellipsis():
+    assert is_instance((), tuple[int, ...])
+    assert is_instance((1,), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_callable():
     assert not is_instance(lambda: None, Callable[[str], None])
@@ -99,12 +117,7 @@ def TODO_test_callable():
     def fun(x: str, y: int) -> bool: ...
     assert is_instance(fun, Callable[[str, int], bool])
 
-def TODO_test_typed_tuples_ellipsis():
-    assert is_instance((), tuple[int, ...])
-    assert is_instance((1,), tuple[int, ...])
-    assert is_instance((1, 2), tuple[int, ...])
-
 def TODO_test_generator():
-    assert is_instance((_ for _ in '__'), Generator[str, None, None])
-    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
+    assert is_instance((_ for _ in ''), Generator[str, None, None])
+    assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive


### PR DESCRIPTION
This PR reorganizes and supersedes #6 and should be merged instead.

Summary:
- Tests were revised to surface some bugs (26c2ee23cafa4e09a9db62c54c020dfc3eac033c) and the corresponding code was fixed (5dd01a823f62836bae091caee669db148e5ee7be) so that all but one of those tests pass (`test_iterator` is still failing for `iter('')`).
- Support has been added for `MutableMapping`, `MutableSequence`, `MutableSet`, and `Set` from `collections.abc` (c72957cce531f507aa821e1af7672e3697109a33) as well as `typing.Literal` (fff276304e494516c8747415745a564b818b021f).
- I fixed a bug in the way we checked Python version (29229d40d440779401be7f142f3554395e85da4b).
- Parameters are now positional-only to mirror the original `isinstance` (149e656ad09758809164cc280fae5936c21fb5f3).
- Support for `types.NoneType` was fixed (e7674b55850644b63c04f0e5c2c1f065cae1609c).
- Python >= 3.10 was added to `pyproject.toml` (149e656ad09758809164cc280fae5936c21fb5f3).

Bugfixes:
- 0b4068b5cba3f9f5270edabc753300e48d1e9856
- 6f1edce1ef6aac8e50a85f96354a6268490e70d3
- 29229d40d440779401be7f142f3554395e85da4b
- 5dd01a823f62836bae091caee669db148e5ee7be
- e7674b55850644b63c04f0e5c2c1f065cae1609c

Docs:
- 80bd9412e238d71d58d24d6edf78f2edd07b6760
- 9ab1afa22136e94cf6a2f60c71fa60aebfdb3ca9

Build:
- d48b016c5a9f72f940ada1073ff6913d16abdff9

Refactor:
- f5791b66dcea5c26e24d5afb3e7c33744533011e

Style:
- 860ba5a8b52102b64b1ba860269b2b1df1f15d57

Tests:
- 26c2ee23cafa4e09a9db62c54c020dfc3eac033c

Features:
- fff276304e494516c8747415745a564b818b021f
- c72957cce531f507aa821e1af7672e3697109a33
- 149e656ad09758809164cc280fae5936c21fb5f3
