### PR TITLE
Improve support for collections, Literal, and NoneType

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is_instance
 
-A better isinstance for python.
+A better `isinstance` for Python.
 
 ## examples
 
@@ -37,7 +37,7 @@ True
 The following type slang is also supported, inspired by the Haskell type system.
 
 ```python3
-import is_instance
+>>> import is_instance
 
 >>> is_instance(['spam', 'and', 'eggs'], [str])
 True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ description = "A better isinstance for python"
 dependencies = [
     "callable_module",
 ]
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 develop = [

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -30,6 +30,9 @@ def is_instance(obj, cls):
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 
+    if isinstance(cls, typing._LiteralGenericAlias):
+        return obj in cls.__args__
+
     if not is_instance(obj, cls.__origin__):
         return False
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -63,7 +63,7 @@ def is_instance(obj, cls):
     raise TypeError(obj, cls)
 
 
-if sys.version >= '3.11':
+if sys.version_info >= (3, 11):
     # translate_slang needs to write cls[*obj],
     # which is apparently a syntax error in older
     # versions of python, so we shouldn't even

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
+from collections.abc import Callable, Container, Generator, Iterable, Mapping
 from functools import reduce
 from operator import or_
 
@@ -52,7 +52,7 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Generator):
         raise NotImplementedError('Generator not yet supported')
 
-    if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
+    if issubclass(outer_type, (Container, Iterable)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
         return all(is_instance(item, inner_type) for item in obj)

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls) -> bool:
+def is_instance(obj, cls, /) -> bool:
 
     ''' Turducken typing. '''
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Callable, Container, Generator, Iterable, Mapping
+from collections.abc import Callable, Container, Generator, Iterable, Iterator, Mapping
 from functools import reduce
 from operator import or_
 
@@ -52,10 +52,15 @@ def is_instance(obj, cls):
     if issubclass(outer_type, Generator):
         raise NotImplementedError('Generator not yet supported')
 
+    if issubclass(outer_type, Iterator):
+        raise NotImplementedError('Iterator not yet supported')
+
     if issubclass(outer_type, (Container, Iterable)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
-        return all(is_instance(item, inner_type) for item in obj)
+        if len(obj):
+            return all(is_instance(item, inner_type) for item in obj)
+        return is_instance(obj, inner_type) or hasattr(obj, '__class_getitem__')
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError('Callable not yet supported')

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -24,6 +24,9 @@ def is_instance(obj, cls):
     if isinstance(cls, (list, set, dict)):
         cls = translate_slang(cls)
 
+    if cls is None:
+        cls = types.NoneType
+
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -11,7 +11,7 @@ from operator import or_
 
 def is_instance(obj, cls):
 
-    """ Turducken typing. """
+    ''' Turducken typing. '''
 
     if isinstance(cls, tuple):
         if all(isinstance(sub, type) for sub in cls):
@@ -35,7 +35,7 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, tuple):
         if Ellipsis in inner_types:
-            raise NotImplementedError("Ellipsis not yet supported")
+            raise NotImplementedError('Ellipsis not yet supported')
         if len(inner_types) != len(obj):
             return False
         return all(is_instance(item, inner_type) for item, inner_type in zip(obj, inner_types))
@@ -58,7 +58,7 @@ def is_instance(obj, cls):
         return all(is_instance(item, inner_type) for item in obj)
 
     if issubclass(outer_type, Callable):
-        raise NotImplementedError("Callable not yet supported")
+        raise NotImplementedError('Callable not yet supported')
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls):
+def is_instance(obj, cls) -> bool:
 
     ''' Turducken typing. '''
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -49,6 +49,9 @@ def is_instance(obj, cls):
             key, val in obj.items()
         )
 
+    if issubclass(outer_type, Generator):
+        raise NotImplementedError('Generator not yet supported')
+
     if issubclass(outer_type, (list, set, Container, Iterable, Sequence)):
         assert len(inner_types) == 1
         [inner_type] = inner_types
@@ -56,9 +59,6 @@ def is_instance(obj, cls):
 
     if issubclass(outer_type, Callable):
         raise NotImplementedError("Callable not yet supported")
-
-    if issubclass(outer_type, Generator):
-        raise NotImplementedError("Generator not yet supported")
 
     raise TypeError(obj, cls)
 

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,7 +5,7 @@ __all__ = [
 import sys
 import types
 import typing
-from collections.abc import Container, Iterable, Mapping, Sequence
+from collections.abc import Callable, Container, Generator, Iterable, Mapping, Sequence
 from functools import reduce
 from operator import or_
 

--- a/src/is_instance/slang.py
+++ b/src/is_instance/slang.py
@@ -2,7 +2,7 @@ __all__ = [
     'translate_slang',
 ]
 def translate_slang(obj):
-    """
+    '''
     Slang for the haskell type system.
 
     Allows using abbreviations like:
@@ -15,9 +15,9 @@ def translate_slang(obj):
 
     Lets us talk about types in a better way
     without having to actually use haskell.
-    """
+    '''
     if len(obj) != 1:
-        raise TypeError(f"Not a valid type schema")
+        raise TypeError(f'Not a valid type schema')
     for cls in (tuple, list, set):
         if isinstance(obj, cls):
             return cls[*obj]

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -6,9 +6,14 @@ from collections.abc import (
     Iterable,
     Iterator,
     Mapping,
+    MutableMapping,
+    MutableSequence,
+    MutableSet,
     Reversible,
     Sequence,
+    Set,
 )
+from types import MappingProxyType
 from typing import Literal
 
 import is_instance
@@ -89,6 +94,11 @@ def test_mapping():
     assert not is_instance({'': ''}, Mapping[str, int])
     assert not is_instance('', Mapping)
 
+def test_mutable_mapping():
+    assert is_instance({'': ''}, MutableMapping[str, str])
+    assert not is_instance({'': ''}, MutableMapping[str, int])
+    assert not is_instance(MappingProxyType({}), MutableMapping)
+
 def test_reversible():
     assert is_instance('', Reversible[str])
     assert is_instance('', Reversible[Reversible[str]])
@@ -100,6 +110,23 @@ def test_sequence():
     assert is_instance('', Sequence[Sequence[str]])
     assert not is_instance('', Sequence[int])
     assert not is_instance(set(), Sequence)
+
+def test_mutable_sequence():
+    assert is_instance([''], MutableSequence[str])
+    assert is_instance([[]], MutableSequence[MutableSequence[None]])
+    assert not is_instance([''], MutableSequence[int])
+    assert not is_instance('', MutableSequence)
+
+def test_set():
+    assert is_instance({''}, Set[str])
+    assert is_instance({frozenset()}, Set[Set[None]])
+    assert not is_instance({''}, Set[int])
+    assert not is_instance([], Set)
+
+def test_mutable_set():
+    assert is_instance({''}, MutableSet[str])
+    assert not is_instance({''}, MutableSet[int])
+    assert not is_instance(frozenset(), MutableSet)
 
 ############
 ### TODO ###

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Reversible,
     Sequence,
 )
+from typing import Literal
 
 import is_instance
 
@@ -57,6 +58,13 @@ def test_slang():
     assert is_instance([d1, d2], [{str: int}])
     assert not is_instance([d1, d2], [{str: bool}])
     assert not is_instance([d1, d2], [{str: str}])
+
+def test_literal():
+    assert is_instance('', Literal[''])
+    assert is_instance('', Literal['', 0])
+    assert is_instance('', Literal[Literal['']])
+    assert not is_instance(Literal[''], Literal[Literal['']])
+    assert not is_instance('', Literal[0])
 
 def test_collection():
     assert is_instance('', Collection[str])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -48,6 +48,7 @@ def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}
     assert is_instance(['spam', 'and', 'eggs'], [str])
+    assert is_instance(None, None)
     assert is_instance([], [int])
     assert is_instance({1, 2, 3}, {int})
     assert is_instance({'bird': True, 'alive': False}, {str: bool})
@@ -58,36 +59,53 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(['cake'], Collection[str])
-    assert not is_instance(['cake'], Collection[int])
+    assert is_instance('', Collection[str])
+    assert is_instance('', Collection[Collection[str]])
+    assert not is_instance('', Collection[int])
+    assert not is_instance(0, Collection)
 
 def test_container():
-    assert is_instance(['cake'], Container[str])
-    assert not is_instance(['cake'], Container[int])
+    assert is_instance('', Container[str])
+    assert is_instance('', Container[Container[str]])
+    assert not is_instance('', Container[int])
+    assert not is_instance(0, Container)
 
 def test_iterable():
-    assert is_instance(['cake'], Iterable[str])
-    assert not is_instance(['cake'], Iterable[int])
+    assert is_instance('', Iterable[str])
+    assert is_instance('', Iterable[Iterable[str]])
+    assert not is_instance('', Iterable[int])
+    assert not is_instance(0, Iterable)
 
 def test_iterator():
-    assert is_instance(iter(['cake']), Iterator[str])
-    assert not is_instance(iter(['cake']), Iterator[int])
+    assert is_instance(iter(''), Iterator[str])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)
 
 def test_mapping():
-    assert is_instance({'cake': 'pie'}, Mapping[str, str])
-    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
+    assert is_instance({'': ''}, Mapping[str, str])
+    assert not is_instance({'': ''}, Mapping[str, int])
+    assert not is_instance('', Mapping)
 
 def test_reversible():
-    assert is_instance(['cake'], Reversible[str])
-    assert not is_instance(['cake'], Reversible[int])
+    assert is_instance('', Reversible[str])
+    assert is_instance('', Reversible[Reversible[str]])
+    assert not is_instance('', Reversible[int])
+    assert not is_instance(set(), Reversible)
 
 def test_sequence():
-    assert is_instance(['cake'], Sequence[str])
-    assert not is_instance(['cake'], Sequence[int])
+    assert is_instance('', Sequence[str])
+    assert is_instance('', Sequence[Sequence[str]])
+    assert not is_instance('', Sequence[int])
+    assert not is_instance(set(), Sequence)
 
 ############
 ### TODO ###
 ############
+
+def TODO_test_typed_tuples_ellipsis():
+    assert is_instance((), tuple[int, ...])
+    assert is_instance((1,), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_callable():
     assert not is_instance(lambda: None, Callable[[str], None])
@@ -96,15 +114,10 @@ def TODO_test_callable():
     assert is_instance(fun, Callable[[str], None])
     def fun(x: str, y: int) -> None: ...
     assert is_instance(fun, Callable[[str, int], None])
-    def fun(x: str, y: int) -> bool: ...
-    assert is_instance(fun, Callable[[str, int], bool])
-
-def TODO_test_typed_tuples_ellipsis():
-    assert is_instance((), tuple[int, ...])
-    assert is_instance((1,), tuple[int, ...])
-    assert is_instance((1, 2), tuple[int, ...])
+    def fun(x: None) -> str: ...
+    assert is_instance(fun, Callable[[None], str])
 
 def TODO_test_generator():
-    assert is_instance((_ for _ in '__'), Generator[str, None, None])
-    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
+    assert is_instance((_ for _ in ''), Generator[str, None, None])
+    assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -58,32 +58,32 @@ def test_slang():
     assert not is_instance([d1, d2], [{str: str}])
 
 def test_collection():
-    assert is_instance(["cake"], Collection[str])
-    assert not is_instance(["cake"], Collection[int])
+    assert is_instance(['cake'], Collection[str])
+    assert not is_instance(['cake'], Collection[int])
 
 def test_container():
-    assert is_instance(["cake"], Container[str])
-    assert not is_instance(["cake"], Container[int])
+    assert is_instance(['cake'], Container[str])
+    assert not is_instance(['cake'], Container[int])
 
 def test_iterable():
-    assert is_instance(["cake"], Iterable[str])
-    assert not is_instance(["cake"], Iterable[int])
+    assert is_instance(['cake'], Iterable[str])
+    assert not is_instance(['cake'], Iterable[int])
 
 def test_iterator():
-    assert is_instance(iter(["cake"]), Iterator[str])
-    assert not is_instance(iter(["cake"]), Iterator[int])
+    assert is_instance(iter(['cake']), Iterator[str])
+    assert not is_instance(iter(['cake']), Iterator[int])
 
 def test_mapping():
-    assert is_instance({"cake": "pie"}, Mapping[str, str])
-    assert not is_instance({"cake": "pie"}, Mapping[str, int])
+    assert is_instance({'cake': 'pie'}, Mapping[str, str])
+    assert not is_instance({'cake': 'pie'}, Mapping[str, int])
 
 def test_reversible():
-    assert is_instance(["cake"], Reversible[str])
-    assert not is_instance(["cake"], Reversible[int])
+    assert is_instance(['cake'], Reversible[str])
+    assert not is_instance(['cake'], Reversible[int])
 
 def test_sequence():
-    assert is_instance(["cake"], Sequence[str])
-    assert not is_instance(["cake"], Sequence[int])
+    assert is_instance(['cake'], Sequence[str])
+    assert not is_instance(['cake'], Sequence[int])
 
 ############
 ### TODO ###
@@ -105,6 +105,6 @@ def TODO_test_typed_tuples_ellipsis():
     assert is_instance((1, 2), tuple[int, ...])
 
 def TODO_test_generator():
-    assert is_instance((_ for _ in "__"), Generator[str, None, None])
-    assert not is_instance((_ for _ in "__"), Generator[int, None, None])
+    assert is_instance((_ for _ in '__'), Generator[str, None, None])
+    assert not is_instance((_ for _ in '__'), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -76,11 +76,6 @@ def test_iterable():
     assert not is_instance('', Iterable[int])
     assert not is_instance(0, Iterable)
 
-def test_iterator():
-    assert is_instance(iter(''), Iterator[str])
-    assert not is_instance(iter(''), Iterator[int])
-    assert not is_instance('', Iterator)
-
 def test_mapping():
     assert is_instance({'': ''}, Mapping[str, str])
     assert not is_instance({'': ''}, Mapping[str, int])
@@ -121,3 +116,9 @@ def TODO_test_generator():
     assert is_instance((_ for _ in ''), Generator[str, None, None])
     assert not is_instance((_ for _ in ''), Generator[int, None, None])
     # TODO: test Generator[...] + send/receive
+
+def TODO_test_iterator():
+    assert is_instance(iter(''), Iterator[str])
+    assert is_instance(iter(iter('')), Iterator[Iterator[str]])
+    assert not is_instance(iter(''), Iterator[int])
+    assert not is_instance('', Iterator)


### PR DESCRIPTION
This PR reorganizes and supersedes #7 and should be merged instead as it corrects some typos in the commit messages.

Summary:
- Tests were revised to surface some bugs (907555b111d5d80e10b9fb037af910aff422218d) and the corresponding code was fixed (b9beca02ea1c8bb9593ed6e042ac708a617c319e) so that all but one of those tests pass (`test_iterator` is still failing for `iter('')`).
- Support has been added for `MutableMapping`, `MutableSequence`, `MutableSet`, and `Set` from `collections.abc` (c85657f8f6f6e86d022cf1de58dc2982db63f96e) as well as `typing.Literal` (11d6e67737693aea440a7351680f160cdb948632).
- I fixed a bug in the way we checked Python version (29229d40d440779401be7f142f3554395e85da4b).
- Parameters are now positional-only to mirror the original `isinstance` (908894f31b706428594cc1485746cfda13b8f9d5).
- Support for `types.NoneType` was fixed (cbe229ce82aac4f7ee01d43726ba3f7f6c588efc).
- Python >= 3.10 was added to `pyproject.toml` (d48b016c5a9f72f940ada1073ff6913d16abdff9).

<details>
<summary>Bugfixes:</summary>

- 0b4068b5cba3f9f5270edabc753300e48d1e9856
- 6f1edce1ef6aac8e50a85f96354a6268490e70d3
- 29229d40d440779401be7f142f3554395e85da4b
- b9beca02ea1c8bb9593ed6e042ac708a617c319e
- cbe229ce82aac4f7ee01d43726ba3f7f6c588efc

</details>

<details>
<summary>Docs:</summary>
- 80bd9412e238d71d58d24d6edf78f2edd07b6760
- 89f713bd7885cd108bac9437f21802d5ba190c32

</details>

<details>
<summary>Build:</summary>
- d48b016c5a9f72f940ada1073ff6913d16abdff9

</details>

<details>
<summary>Refactor:</summary>
- f5791b66dcea5c26e24d5afb3e7c33744533011e

</details>

<details>
<summary>Style:</summary>
- 860ba5a8b52102b64b1ba860269b2b1df1f15d57

</details>

<details>
<summary>Tests:</summary>
- 907555b111d5d80e10b9fb037af910aff422218d

</details>

<details>
<summary>Features:</summary>
- 11d6e67737693aea440a7351680f160cdb948632
- c85657f8f6f6e86d022cf1de58dc2982db63f96e
- 908894f31b706428594cc1485746cfda13b8f9d5

</details>