### PR TITLE
Add support for tuples of parameterized generics as second argument

### DIFF
--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -6,17 +6,13 @@ import sys
 import types
 import typing
 from collections.abc import Callable, Container, Generator, Iterable, Iterator, Mapping
-from functools import reduce
-from operator import or_
+
 
 def is_instance(obj, cls):
 
     """ Turducken typing. """
 
     if isinstance(cls, tuple):
-        if all(isinstance(sub, type) for sub in cls):
-            cls = reduce(or_, cls)
-            return is_instance(obj, cls)
         return any(is_instance(obj, sub) for sub in cls)
 
     if sys.version_info >= (3,10) and isinstance(cls, types.UnionType):

--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -17,6 +17,7 @@ def is_instance(obj, cls):
         if all(isinstance(sub, type) for sub in cls):
             cls = reduce(or_, cls)
             return is_instance(obj, cls)
+        return any(is_instance(obj, sub) for sub in cls)
 
     if sys.version_info >= (3,10) and isinstance(cls, types.UnionType):
         return any(is_instance(obj, sub) for sub in cls.__args__)

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -21,7 +21,7 @@ def test_nesting():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}
     assert is_instance(['spam', 'and', 'eggs'], list[str])
-    assert is_instance([], list[int])
+    assert is_instance([], (list[int],))
     assert is_instance({1, 2, 3}, set[int])
     assert is_instance({'bird': True, 'alive': False}, dict[str, bool])
     assert is_instance([{3: int}, {'s': str}], list[dict[object, type]])

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -1,10 +1,7 @@
 from collections.abc import (
-    Callable,
     Collection,
     Container,
-    Generator,
     Iterable,
-    Iterator,
     Mapping,
     Reversible,
     Sequence,


### PR DESCRIPTION
Regarding aaf256f0653a89d0f8e93fd1be7861b0c1ec726a, I'm not sure why the code that was on line 17 was needed, but maybe I'm missing something; tests pass either way on Python 3.11.

The bug is related to the last test case mentioned in #10.