### PR TITLE
Support checking against tuple annotations with Ellipsis

### DIFF
--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -5,8 +5,10 @@ __all__ = [
 import sys
 import types
 import typing
+from collections import deque
 from collections.abc import Callable, Container, Generator, Iterable, Iterator, Mapping
 from functools import reduce
+from itertools import groupby
 from operator import or_
 
 def is_instance(obj, cls):
@@ -40,6 +42,8 @@ def is_instance(obj, cls):
         return False
 
     if issubclass(cls_origin, tuple):
+        if Ellipsis in cls_args:
+            return _ellipsis(obj, cls_args)
         if len(cls_args) != len(obj):
             return False
         return all(is_instance(item, cls_arg) for item, cls_arg in zip(obj, cls_args))
@@ -70,6 +74,37 @@ def is_instance(obj, cls):
         raise NotImplementedError('Callable not yet supported')
 
     raise TypeError(obj, cls)
+
+
+def _ellipsis(objs, types_, /) -> bool:
+    """Check if objs is a valid ordering according to types in the subscript."""
+    objs, types_ = deque(objs), deque(types_)
+
+    # trim initial/terminal non-Ellipsis
+    for idx in (0, -1):
+        pop_side = f"pop{'left' * (idx + 1)}"
+        pop_objs, pop_types = getattr(objs, pop_side), getattr(types_, pop_side)
+        while types_ and types_[idx] is not Ellipsis:
+            if not (objs and is_instance(pop_objs(), pop_types())):
+                return False
+            continue
+    assert types_[0] is Ellipsis and types_[-1] is Ellipsis
+
+    pop_objs = objs.popleft
+    for current_types in (  # split remaining types on Ellipsis into consecutive groups
+        deque(group)  # incidentally, this collapses consecutive Ellipsis args
+        for key, group in groupby(types_, lambda typ: typ is Ellipsis)
+        if not key
+    ):
+        pop_types = current_types.popleft
+        while current_types:
+            if objs:
+                if is_instance(pop_objs(), current_types[0]):
+                    pop_types()
+                continue
+            return False
+
+    return True
 
 
 if sys.version_info >= (3, 11):

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -44,6 +44,19 @@ def test_typed_tuples():
     assert not isinstance(('cake', 'pie', 42), (str, str, int))
     assert not is_instance(('cake', 'pie', 42), (str, str, int))
 
+
+def test_tuple_ellipsis():
+    assert is_instance((), tuple[...])
+    assert is_instance((1,), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ...])
+    assert is_instance((1, None), tuple[int, ...])
+    assert is_instance((1, 2), tuple[int, ..., ..., int])
+    assert is_instance((1, None, 2, 3), tuple[int, ..., int, int])
+    assert is_instance((1, 2, None, 3), tuple[int, int, ..., int])
+    assert is_instance((1, 2, 3), tuple[int, ..., int, ..., int])
+    assert not is_instance((), tuple[int, ...])
+
+
 def test_slang():
     d1 = {'age': 88, 'old': True}
     d2 = {'age': 22, 'old': False}


### PR DESCRIPTION
This PR enables `is_instance` to check against tuples hinted with `Ellipsis` to indicate variable length as described in https://docs.python.org/3/library/typing.html#annotating-tuples. My pylance linter likes to tell me that `Ellipsis` is only valid as the second of two arguments when subscripting, but that is too prescriptive for `is_instance`. This PR allows `Ellipsis` to represent 0 or more objects of any type in the object under examination. I tried my best to keep the tests minimal, but you may wish to condense the cases further. Here are multitudinous additional test cases that illustrate the new functionality:

<details>
  <summary>positive examples</summary>

```python
assert is_instance(("1", "None", 0, "2", None, "3"), tuple[..., int, ..., ...])
assert is_instance((1, "None", 2, None, "3"), tuple[..., str, int, ..., ..., str])
assert is_instance((1, "None", 2, None, "3"), tuple[..., str, int, ..., str])
assert is_instance((1, "None", 2, None, "3"), tuple[..., str])
assert is_instance((1, "None", 2, None, 3), tuple[..., int, ..., ...])
assert is_instance((1, "None", 2, None, 3), tuple[..., int])
assert is_instance((1, "None", 2, None, 3), tuple[..., str, int, ..., int])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., ..., ...])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., ..., int])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., int, ...])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., int, int])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., int, int, int])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, int, int, int, int])
assert is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, int, int, int, int, int, int])
assert is_instance(
    (1, 2, 3, 3, None, None, 5, 6, 7), tuple[int, ..., int, ..., int, int, int]
)
assert is_instance((1, 2, 3), tuple[int, ..., ..., ..., int])
assert is_instance((1, 2, 3), tuple[int, ..., ..., int])
assert is_instance((1, 2, 3), tuple[int, ..., int, ..., int])
assert is_instance((1, 2, 3), tuple[int, ..., int, int])
assert is_instance((1, 2, 3), tuple[int, ..., int])
assert is_instance((1, 2, 3), tuple[int, int, ..., int])
assert is_instance((1, 2), tuple[int, ..., ..., ..., ..., int])
assert is_instance((1, 2), tuple[int, ...])
assert is_instance(
    (1, None, 1, 1, 1, 11, 1, 1, 9, 1, 1, 1, 1, 2),
    tuple[int, ..., ..., None, ..., ..., int],
)
assert is_instance((1, None, 2, None, 3), tuple[..., int])
assert is_instance((1, None, 2, None, 3), tuple[int, ...])
assert is_instance((1, None, 2), tuple[int, ..., ..., ..., ..., int])
assert is_instance((1, None, 2), tuple[int, ..., ..., int])
assert is_instance((1, None, 2), tuple[int, ..., int])
assert is_instance((1, None, 2), tuple[int, ..., None, ..., int])
assert is_instance((1,), tuple[...])
assert is_instance((1,), tuple[int, ...])
assert is_instance((1,), tuple[int])
assert is_instance(
    (None, 1, 2, 3, 3, 5, 6, 7), tuple[None, int, ..., int, ..., ..., ..., ...]
)
```
</details>

<details>
  <summary>negative examples</summary>

```python  
assert not is_instance(
    (1, 1, 1, 1, 11, 1, 1, 9, 1, 1, 1, 1, 2), tuple[int, ..., ..., None, ..., ..., int]
)
assert not is_instance(("1", "None", "2", None, "3"), tuple[..., int, ..., ...])
assert not is_instance((), tuple[int, ..., int])
assert not is_instance((), tuple[int, ...])
assert not is_instance((1, ""), tuple[int, str, int])
assert not is_instance((1, "None", 2, None, 3), tuple[..., str, int, ..., ..., str])
assert not is_instance((1, "None", 2, None, 3), tuple[..., str, int, ..., str])
assert not is_instance((1, "None", 2, None, 3), tuple[..., str])
assert not is_instance((1, "None", 2, None), tuple[..., str, int, ..., ..., str])
assert not is_instance((1, "None", 2, None), tuple[..., str, int, ..., str, ...])
assert not is_instance(
    (1, 2, 3, 3, 5, 6, 7, None), tuple[int, ..., int, ..., ..., int, int]
)
assert not is_instance(
    (1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., None, ..., ..., int]
)
assert not is_instance((1, 2, 3, 3, 5, 6, 7), tuple[int, ..., None, ..., ..., int, ...])
assert not is_instance((1, 2, 3, 3, 5, 6), tuple[int, int, int, int, int, int, int])
assert not is_instance(
    (1, 2, 3, 3, 5, None, 6, 7), tuple[int, ..., int, ..., int, int, int]
)
assert not is_instance((1, 2, 3, 3, 5), tuple[int, ..., int, int, int, int, int])
assert not is_instance((1, 2, 3), tuple[int, ..., ..., ..., str])
assert not is_instance((1, 2, 3), tuple[int, ..., ..., str])
assert not is_instance((1, 2, 3), tuple[int, ..., str])
assert not is_instance((1, 2, 3), tuple[str, ..., int])
assert not is_instance((1, None, 2, None, 3), tuple[..., str, ...])
assert not is_instance((1, None, 2), tuple[int, ..., ..., ..., ..., str])
assert not is_instance((1, None, 2), tuple[int, ..., int, ..., int])
assert not is_instance((1,), tuple[int, ..., ..., int])
assert not is_instance((1,), tuple[int, ..., int, ..., int, int, int])
assert not is_instance((1,), tuple[int, ..., int])
assert not is_instance((1,), tuple[int, int])
assert not is_instance((1,), tuple[int, str, int])
assert not is_instance(
    (None, 1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., ..., ...]
)
assert not is_instance(
    (None, 1, 2, 3, 3, 5, 6, 7), tuple[int, ..., int, ..., ..., ..., int]
)
assert not is_instance((None,), tuple[int, ..., int, ..., int, int, int])
```
</details>

The algorithm represents the tuple object and the subscripting type args as two deques and iteratively compares their elements with `is_instance` checks. Leading or trailing non-`Ellipsis` annotations "anchor" either end of the tuple object deque and are checked first. If no check has failed yet, the remaining elements of the type args deque are split on `Ellipsis` to derive consecutive sequences of non-`Ellipsis` type args (incidentally collapsing superfluous consecutive `Ellipsis` type args); these are used like "quotas" that must be filled for `is_instance` to return `True`.

I think `Ellipsis` support will be complete when we finish supporting `Callable`; as far as I know, there aren't any others that typically are subscripted with `Ellipsis`.