### PR TITLE
Prefer positional-only parameters

### DIFF
--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Container, Generator, Iterable, Iterator, 
 from functools import reduce
 from operator import or_
 
-def is_instance(obj, cls):
+def is_instance(obj, cls, /):
 
     """ Turducken typing. """
 


### PR DESCRIPTION
To better mirror the signature of original `isinstance`, I propose that the parameters be positional only.