### PR TITLE
feat: support bottom types

### DIFF
--- a/src/is_instance/main.py
+++ b/src/is_instance/main.py
@@ -27,6 +27,13 @@ def is_instance(obj, cls):
     if cls is None:
         cls = types.NoneType
 
+    if sys.version_info >= (3, 6, 2):
+        if cls == typing.NoReturn:
+            return False
+        if sys.version_info >= (3, 11):
+            if cls == typing.Never:
+                return False
+
     if not isinstance(cls, (types.GenericAlias, typing._GenericAlias)):
         return isinstance(obj, cls)
 

--- a/tests/test_is_instance.py
+++ b/tests/test_is_instance.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Reversible,
     Sequence,
 )
+from typing import Never, NoReturn
 
 import is_instance
 
@@ -80,3 +81,7 @@ def test_reversible():
 def test_sequence():
     assert is_instance(["cake"], Sequence[str])
     assert not is_instance(["cake"], Sequence[int])
+
+def test_bottom_types():
+    assert not is_instance("cake", Never)
+    assert not is_instance("cake", NoReturn)


### PR DESCRIPTION
Adds support for `typing.Never` and `typing.NoReturn`

Note that `is_instance(object, (typing.Never, typing.NoReturn))` will still raise `TypeError` until the changes from #11 are merged.